### PR TITLE
Make WindowState nullable for ShutterContact

### DIFF
--- a/src/HomematicIp/Data/HomematicIpObjects/Channels/ShutterContactChannel.cs
+++ b/src/HomematicIp/Data/HomematicIpObjects/Channels/ShutterContactChannel.cs
@@ -5,7 +5,7 @@ namespace HomematicIp.Data.HomematicIpObjects.Channels
     [EnumMap(FunctionalChannelType.SHUTTER_CONTACT_CHANNEL)]
     public class ShutterContactChannel : DeviceSabotageChannelBase
     {
-        public WindowState WindowState { get; set; }
+        public WindowState? WindowState { get; set; }
         public int EventDelay { get; set; }
     }
 }


### PR DESCRIPTION
Solves:
```csharp
Newtonsoft.Json.JsonSerializationException: Cannot convert null value to HomematicIp.Data.Enums.WindowState. Path 'windowState', line 13, position 21.
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at HomematicIp.Data.JsonConverters.AbstractListConverter`2.ReadJson(JsonReader reader, Type objectType, List`1 existingValue, Boolean hasExistingValue, JsonSerializer serializer) in /Users/eschaefer/Documents/GitHub/HomematicIp/src/HomematicIp/Data/JsonConverters/AbstractListConverter.cs:line 31
   at Newtonsoft.Json.JsonConverter`1.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at HomematicIp.Data.JsonConverters.AbstractListConverter`2.ReadJson(JsonReader reader, Type objectType, List`1 existingValue, Boolean hasExistingValue, JsonSerializer serializer) in /Users/eschaefer/Documents/GitHub/HomematicIp/src/HomematicIp/Data/JsonConverters/AbstractListConverter.cs:line 31
   at Newtonsoft.Json.JsonConverter`1.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at HomematicIp.Services.HomematicService.GetCurrentState(CancellationToken cancellationToken) in /Users/eschaefer/Documents/GitHub/HomematicIp/src/HomematicIp/Services/HomematicService.cs:line 54
   at HomematicIp.Console.Program.Main(String[] args) in /Users/eschaefer/Documents/GitHub/HomematicIp/src/HomematicIp.Console/Program.cs:line 74
```